### PR TITLE
add missing include to get code to compile on MacOSX

### DIFF
--- a/gcif.cpp
+++ b/gcif.cpp
@@ -28,6 +28,8 @@
 
 #include <iostream>
 #include <vector>
+#include <unistd.h>
+
 using namespace std;
 
 #include "encoder/Log.hpp"


### PR DESCRIPTION
Fix build under clang on MacOSX.
